### PR TITLE
Fixed geometry type to fit literal type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
 	</properties>
 
 	<dependencies>
+	<dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>2.11.1</version>
+</dependency>
 		<dependency>
 			<groupId>org.hobbit</groupId>
 			<artifactId>core</artifactId>

--- a/src/main/resources/gsb_dataset/dataset.rdf
+++ b/src/main/resources/gsb_dataset/dataset.rdf
@@ -459,7 +459,7 @@
     <geo:hasGeometry rdf:resource="http://example.org/ApplicationSchema#JExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:LineString rdf:about="http://example.org/ApplicationSchema#JExactGeom">
+<sf:Polygon rdf:about="http://example.org/ApplicationSchema#JExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>
@@ -484,7 +484,7 @@
     <geo:hasGeometry rdf:resource="http://example.org/ApplicationSchema#KExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:LineString rdf:about="http://example.org/ApplicationSchema#KExactGeom">
+<sf:Polygon rdf:about="http://example.org/ApplicationSchema#KExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>
@@ -509,7 +509,7 @@
     <geo:hasGeometry rdf:resource="http://example.org/ApplicationSchema#LExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:LineString rdf:about="http://example.org/ApplicationSchema#LExactGeom">
+<sf:Point rdf:about="http://example.org/ApplicationSchema#LExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>
@@ -531,7 +531,7 @@
     <my:hasExactGeometry rdf:resource="http://example.org/ApplicationSchema#MExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:LineString rdf:about="http://example.org/ApplicationSchema#MExactGeom">
+<sf:Point rdf:about="http://example.org/ApplicationSchema#MExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>

--- a/src/main/resources/gsb_dataset/dataset.rdf
+++ b/src/main/resources/gsb_dataset/dataset.rdf
@@ -459,7 +459,7 @@
     <geo:hasGeometry rdf:resource="http://example.org/ApplicationSchema#JExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:Polygon rdf:about="http://example.org/ApplicationSchema#JExactGeom">
+<sf:LineString rdf:about="http://example.org/ApplicationSchema#JExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>
@@ -484,7 +484,7 @@
     <geo:hasGeometry rdf:resource="http://example.org/ApplicationSchema#KExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:Polygon rdf:about="http://example.org/ApplicationSchema#KExactGeom">
+<sf:LineString rdf:about="http://example.org/ApplicationSchema#KExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>
@@ -509,7 +509,7 @@
     <geo:hasGeometry rdf:resource="http://example.org/ApplicationSchema#LExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:Point rdf:about="http://example.org/ApplicationSchema#LExactGeom">
+<sf:LineString rdf:about="http://example.org/ApplicationSchema#LExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>
@@ -531,7 +531,7 @@
     <my:hasExactGeometry rdf:resource="http://example.org/ApplicationSchema#MExactGeom"/>
 </my:PlaceOfInterest>
 
-<sf:Point rdf:about="http://example.org/ApplicationSchema#MExactGeom">
+<sf:LineString rdf:about="http://example.org/ApplicationSchema#MExactGeom">
     <rdf:type rdf:resource="http://www.opengis.net/ont/geosparql#Geometry"/>
     <rdf:type rdf:resource="http://www.opengis.net/ont/gml#LineString"/>
     <geo:isEmpty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</geo:isEmpty>


### PR DESCRIPTION
I fixed some geometry types in the benchmark dataset.
I went through all the queries and could not find a reference that would depend on the types.
So in my opinion this fix should not affect the results of the GeoSPARQL benchmark.
We should test it though.