### PR TITLE
GML File fix: Use URIs for CRS instead of URN

### DIFF
--- a/src/main/resources/gsb_dataset/dataset.gml
+++ b/src/main/resources/gsb_dataset/dataset.gml
@@ -4,11 +4,11 @@
      xsi:schemaLocation="http://ogr.maptools.org/ dataset_2.xsd"
      xmlns:ogr="http://ogr.maptools.org/"
      xmlns:gml="http://www.opengis.net/gml">
-  <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-88.38 -88.38</gml:lowerCorner><gml:upperCorner>38.913574 31.95</gml:upperCorner></gml:Envelope></gml:boundedBy>                                                                                                                                                       
+  <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-88.38 -88.38</gml:lowerCorner><gml:upperCorner>31.95 38.913574</gml:upperCorner></gml:Envelope></gml:boundedBy>                                                                                                                                                       
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.0">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.1 -83.6</gml:lowerCorner><gml:upperCorner>34.5 -83.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>34.1 -83.6 34.1 -83.2 34.5 -83.2 34.5 -83.6 34.1 -83.6</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.6 34.1</gml:lowerCorner><gml:upperCorner>-83.2 34.5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-83.6 34.1 -83.2 34.1 -83.2 34.5 -83.6 34.5 -83.6 34.1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>AExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -19,8 +19,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.1">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.1 -83.6</gml:lowerCorner><gml:upperCorner>34.3 -83.4</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>34.1 -83.6 34.1 -83.4 34.3 -83.4 34.3 -83.6 34.1 -83.6</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.6 34.1</gml:lowerCorner><gml:upperCorner>-83.4 34.3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-83.6 34.1 -83.4 34.1 -83.4 34.3 -83.6 34.3 -83.6 34.1</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>BExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -31,8 +31,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.2">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.2 -83.5</gml:lowerCorner><gml:upperCorner>34.2 -83.5</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>34.2 -83.5</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.5 34.2</gml:lowerCorner><gml:upperCorner>-83.5 34.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:pos>-83.5 34.2</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>BPointGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_isEmpty>false</ogr:geo_isEmpty>
@@ -42,8 +42,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.3">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.3 -83.2</gml:lowerCorner><gml:upperCorner>34.5 -83.0</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>34.3 -83.2 34.3 -83.0 34.5 -83.0 34.5 -83.2 34.3 -83.2</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.2 34.3</gml:lowerCorner><gml:upperCorner>-83.0 34.5</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-83.2 34.3 -83.0 34.3 -83.0 34.5 -83.2 34.5 -83.2 34.3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>CExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -54,8 +54,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.4">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.4 -83.1</gml:lowerCorner><gml:upperCorner>34.4 -83.1</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>34.4 -83.1</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.1 34.4</gml:lowerCorner><gml:upperCorner>-83.1 34.4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:pos>-83.1 34.4</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>CPointGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -66,8 +66,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.5">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.0 -83.3</gml:lowerCorner><gml:upperCorner>34.2 -83.1</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>34.0 -83.3 34.0 -83.1 34.2 -83.1 34.2 -83.3 34.0 -83.3</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.3 34.0</gml:lowerCorner><gml:upperCorner>-83.1 34.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-83.3 34.0 -83.1 34.0 -83.1 34.2 -83.3 34.2 -83.3 34.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>DExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -78,8 +78,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.6">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.1 -83.2</gml:lowerCorner><gml:upperCorner>34.1 -83.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>34.1 -83.2</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.2 34.1</gml:lowerCorner><gml:upperCorner>-83.2 34.1</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:pos>-83.2 34.1</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>DPointGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -90,8 +90,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.7">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.0 -83.4</gml:lowerCorner><gml:upperCorner>34.3 -83.3</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:LineString srsName="urn:ogc:def:crs:EPSG::4326"><gml:posList>34.0 -83.4 34.3 -83.3</gml:posList></gml:LineString></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.4 34.0</gml:lowerCorner><gml:upperCorner>-83.3 34.3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:LineString srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:posList>-83.4 34.0 -83.3 34.3</gml:posList></gml:LineString></ogr:geometryProperty>
       <ogr:rdfs_label>EExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -102,8 +102,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.8">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.4 -83.4</gml:lowerCorner><gml:upperCorner>34.4 -83.4</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>34.4 -83.4</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.4 34.4</gml:lowerCorner><gml:upperCorner>-83.4 34.4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:pos>-83.4 34.4</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>FExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -114,8 +114,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.9">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.2 -83.5</gml:lowerCorner><gml:upperCorner>34.4 -83.3</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>34.2 -83.5 34.2 -83.3 34.4 -83.3 34.4 -83.5 34.2 -83.5</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.5 34.2</gml:lowerCorner><gml:upperCorner>-83.3 34.4</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-83.5 34.2 -83.3 34.2 -83.3 34.4 -83.5 34.4 -83.5 34.2</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>GExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -126,8 +126,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.10">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>34.3 -83.4</gml:lowerCorner><gml:upperCorner>34.3 -83.4</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>34.3 -83.4</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-83.4 34.3</gml:lowerCorner><gml:upperCorner>-83.4 34.3</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:pos>-83.4 34.3</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>GPointGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -178,8 +178,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.15">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>38.886321 -77.089005</gml:lowerCorner><gml:upperCorner>38.913574 -77.029953</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>38.913574 -77.089005 38.913574 -77.029953 38.886321 -77.029953 38.886321 -77.089005 38.913574 -77.089005</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-77.089005 38.886321</gml:lowerCorner><gml:upperCorner>-77.029953 38.913574</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-77.089005 38.913574 -77.029953 38.913574 -77.029953 38.886321 -77.089005 38.886321 -77.089005 38.913574</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>JExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -190,8 +190,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.16">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>38.886321 -77.089005</gml:lowerCorner><gml:upperCorner>38.913574 -77.029953</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326"><gml:exterior><gml:LinearRing><gml:posList>38.913574 -77.089005 38.913574 -77.029953 38.886321 -77.029953 38.886321 -77.089005 38.913574 -77.089005</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-77.089005 38.886321</gml:lowerCorner><gml:upperCorner>-77.029953 38.913574</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Polygon srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:exterior><gml:LinearRing><gml:posList>-77.089005 38.913574 -77.029953 38.913574 -77.029953 38.886321 -77.089005 38.886321 -77.089005 38.913574</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon></ogr:geometryProperty>
       <ogr:rdfs_label>KExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -202,8 +202,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.17">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>31.95 -88.38</gml:lowerCorner><gml:upperCorner>31.95 -88.38</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>31.95 -88.38</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:lowerCorner>-88.38 31.95 </gml:lowerCorner><gml:upperCorner>-88.38 31.95</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><gml:pos>-88.38 31.95</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>LExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>
@@ -214,8 +214,8 @@
   </ogr:featureMember>
   <ogr:featureMember>
     <ogr:dataset_2 gml:id="dataset_2.18">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>-88.38 31.95</gml:lowerCorner><gml:upperCorner>-88.38 31.95</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <ogr:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326"><gml:pos>-88.38 31.95</gml:pos></gml:Point></ogr:geometryProperty>
+      <gml:boundedBy><gml:Envelope srsName="http://www.opengis.net/def/crs/EPSG/0/4326"><gml:lowerCorner>31.95 -88.38</gml:lowerCorner><gml:upperCorner>31.95 -88.38</gml:upperCorner></gml:Envelope></gml:boundedBy>
+      <ogr:geometryProperty><gml:Point srsName="http://www.opengis.net/def/crs/EPSG/0/4326"><gml:pos>31.95 -88.38</gml:pos></gml:Point></ogr:geometryProperty>
       <ogr:rdfs_label>MExactGeom</ogr:rdfs_label>
       <ogr:geo_coordinateDimension>2</ogr:geo_coordinateDimension>
       <ogr:geo_dimension>2</ogr:geo_dimension>


### PR DESCRIPTION
Fixes issues in the GML file concerning CRS URIs and coordinate representations